### PR TITLE
fix #1 - 사용자 예외처리 수정

### DIFF
--- a/src/main/java/com/wanted/teamV/repository/MemberRepository.java
+++ b/src/main/java/com/wanted/teamV/repository/MemberRepository.java
@@ -1,6 +1,8 @@
 package com.wanted.teamV.repository;
 
 import com.wanted.teamV.entity.Member;
+import com.wanted.teamV.exception.CustomException;
+import com.wanted.teamV.exception.ErrorCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -12,6 +14,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByAccount(String account);
 
     default Member getByAccount(String account) {
-        return findByAccount(account).orElseThrow();
+        return findByAccount(account).orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
     }
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**
- MemberRepository getByAccount()에서 사용자 계정을 못 찾을 경우 MEMBER_NOT_FOUND 예외 처리

**TO-BE**


### 테스트
- [ ] 테스트 코드
- [ ] API 테스트