### PR TITLE
feat #11 - 지출 통계 API 구현

### DIFF
--- a/src/main/java/com/wanted/teamV/component/DummyData.java
+++ b/src/main/java/com/wanted/teamV/component/DummyData.java
@@ -1,0 +1,82 @@
+package com.wanted.teamV.component;
+
+import com.wanted.teamV.entity.Category;
+import com.wanted.teamV.entity.Member;
+import com.wanted.teamV.entity.Spend;
+import com.wanted.teamV.repository.CategoryRepository;
+import com.wanted.teamV.repository.MemberRepository;
+import com.wanted.teamV.repository.SpendRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Random;
+
+@Component
+@RequiredArgsConstructor
+public class DummyData {
+
+    private final MemberRepository memberRepository;
+    private final CategoryRepository categoryRepository;
+    private final SpendRepository spendRepository;
+
+    @PostConstruct
+    public void generateDummyData() {
+        generateSpendDummyData();
+    }
+
+    private void generateSpendDummyData() {
+        List<Member> memberList = memberRepository.findAll();
+        List<Category> categoryList = categoryRepository.findAll();
+        LocalDateTime current = LocalDateTime.now();
+        int currentYear = current.getYear();
+        int currentMonth = current.getMonthValue();
+
+        Random rand = new Random();
+
+        for (int i = 0; i < 50; i++) {
+            YearMonth currentYearMonth = YearMonth.of(currentYear, currentMonth);
+
+            int ranMember = rand.nextInt(memberList.size());
+            int ranCategory = rand.nextInt(categoryList.size());
+            int ranAmount = rand.nextInt(50000) + 1000;
+            int ranMonth = rand.nextInt(currentMonth) + 1;
+            int ranDay = rand.nextInt(currentYearMonth.lengthOfMonth()) + 1;
+
+            Spend spend = Spend.builder()
+                    .member(memberList.get(ranMember))
+                    .category(categoryList.get(ranCategory))
+                    .amount(ranAmount)
+                    .memo(ranMemo(ranCategory))
+                    .date(LocalDateTime.of(currentYear, ranMonth, ranDay, 0, 0, 0))
+                    .build();
+
+            spendRepository.save(spend);
+        }
+    }
+
+    private String ranMemo(int ranCategory) {
+        switch (ranCategory) {
+            case 0:
+                return "식비";
+            case 1:
+                return "교통";
+            case 2:
+                return "금융";
+            case 3:
+                return "야구";
+            case 4:
+                return "쇼핑";
+            case 5:
+                return "생활";
+            case 6:
+                return "주거/통신";
+            case 7:
+                return "의료/건강";
+        }
+        return "default";
+    }
+}

--- a/src/main/java/com/wanted/teamV/component/DummyData.java
+++ b/src/main/java/com/wanted/teamV/component/DummyData.java
@@ -8,6 +8,7 @@ import com.wanted.teamV.repository.MemberRepository;
 import com.wanted.teamV.repository.SpendRepository;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -17,6 +18,7 @@ import java.util.Random;
 
 @Component
 @RequiredArgsConstructor
+@Profile("test-data")
 public class DummyData {
 
     private final MemberRepository memberRepository;

--- a/src/main/java/com/wanted/teamV/controller/StatisticsController.java
+++ b/src/main/java/com/wanted/teamV/controller/StatisticsController.java
@@ -1,0 +1,35 @@
+package com.wanted.teamV.controller;
+
+import com.wanted.teamV.component.AuthenticationPrincipal;
+import com.wanted.teamV.dto.LoginMember;
+import com.wanted.teamV.dto.res.StatisticsResDto;
+import com.wanted.teamV.service.StatisticsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/statistics")
+public class StatisticsController {
+
+    private final StatisticsService statisticsService;
+
+    @GetMapping("/monthly")
+    public ResponseEntity<StatisticsResDto> getMonthlyStatistics(
+            @AuthenticationPrincipal LoginMember loginMember
+    ) {
+        StatisticsResDto response = statisticsService.getMonthlyStatistics(loginMember.id());
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/day")
+    public ResponseEntity<Double> getDayStatistics(
+            @AuthenticationPrincipal LoginMember loginMember
+    ) {
+        Double response = statisticsService.getDayStatistics(loginMember.id());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/wanted/teamV/dto/res/StatisticsResDto.java
+++ b/src/main/java/com/wanted/teamV/dto/res/StatisticsResDto.java
@@ -1,0 +1,13 @@
+package com.wanted.teamV.dto.res;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+@Builder
+public class StatisticsResDto {
+    private Double totalSpend;
+    private Map<String, Double> categorySpendPercentage;
+}

--- a/src/main/java/com/wanted/teamV/service/StatisticsService.java
+++ b/src/main/java/com/wanted/teamV/service/StatisticsService.java
@@ -1,0 +1,11 @@
+package com.wanted.teamV.service;
+
+import com.wanted.teamV.dto.res.StatisticsResDto;
+
+public interface StatisticsService {
+
+    StatisticsResDto getMonthlyStatistics(Long memberId);
+
+    Double getDayStatistics(Long memberId);
+
+}

--- a/src/main/java/com/wanted/teamV/service/impl/StatisticsServiceImpl.java
+++ b/src/main/java/com/wanted/teamV/service/impl/StatisticsServiceImpl.java
@@ -1,0 +1,124 @@
+package com.wanted.teamV.service.impl;
+
+import com.wanted.teamV.dto.res.StatisticsResDto;
+import com.wanted.teamV.entity.Member;
+import com.wanted.teamV.entity.Spend;
+import com.wanted.teamV.exception.CustomException;
+import com.wanted.teamV.exception.ErrorCode;
+import com.wanted.teamV.repository.MemberRepository;
+import com.wanted.teamV.repository.SpendRepository;
+import com.wanted.teamV.service.StatisticsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StatisticsServiceImpl implements StatisticsService {
+
+    private final MemberRepository memberRepository;
+    private final SpendRepository spendRepository;
+
+    @Override
+    public StatisticsResDto getMonthlyStatistics(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        LocalDateTime today = LocalDateTime.now();
+        int year = today.getYear();
+        int month = today.getMonthValue();
+        int day = today.getDayOfMonth();
+
+        LocalDateTime beforeLastMonth = LocalDateTime.of(year, month - 2, day, 0, 0, 0);
+        LocalDateTime lastMonth = LocalDateTime.of(year, month - 1, day, 0, 0, 0);
+
+        List<Spend> lastSpends = spendRepository.findSpendsByDateBetween(memberId, beforeLastMonth, lastMonth);
+        List<Spend> thisSpends = spendRepository.findSpendsByDateBetween(memberId, lastMonth, today);
+
+        //StatisticsResDto -> totalSpend
+        Double lastAllSpend = getSumBySpends(lastSpends);
+        Double thisAllSpend = getSumBySpends(thisSpends);
+
+        //StatisticsResDto -> categorySpendPercentage
+        Map<String, Double> lastMonthCategorySpend = getCategorySpends(lastSpends);
+        Map<String, Double> thisMonthCategorySpend = getCategorySpends(thisSpends);
+
+        Map<String, Double> categorySpendRatio = new HashMap<>();
+        for (Map.Entry<String, Double> entry : thisMonthCategorySpend.entrySet()) {
+            String category = entry.getKey();
+            Double spendLastMonth = lastMonthCategorySpend.getOrDefault(category, 0.0);
+            Double spendThisMonth = entry.getValue();
+
+            Double categoryRatio;
+
+            if (spendLastMonth != 0) {
+                categoryRatio = ((spendThisMonth - spendLastMonth) / spendLastMonth) * 100.0;
+            } else {
+                categoryRatio = 0.0;
+            }
+
+            double roundRatio = Math.round(categoryRatio);
+            categorySpendRatio.put(category, roundRatio);
+        }
+
+        return StatisticsResDto.builder()
+                .totalSpend(thisAllSpend - lastAllSpend)
+                .categorySpendPercentage(categorySpendRatio)
+                .build();
+    }
+
+    @Override
+    public Double getDayStatistics(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        LocalDateTime today = LocalDateTime.now();
+        LocalDateTime startOfDay = today.toLocalDate().atStartOfDay();
+        LocalDateTime endOfDay = today.toLocalDate().atTime(LocalTime.MAX);
+
+        DayOfWeek dayOfWeek = today.getDayOfWeek();
+        LocalDateTime lastWeekSameDay = today.minusWeeks(1).with(TemporalAdjusters.previousOrSame(dayOfWeek));
+
+        List<Spend> todaySpends = spendRepository.findSpendsByDateBetween(memberId, startOfDay, endOfDay);
+        List<Spend> lastWeekDaySpends = spendRepository.findSpendsByDateBetween(
+                memberId,
+                lastWeekSameDay.toLocalDate().atStartOfDay(),
+                lastWeekSameDay.toLocalDate().atTime(LocalTime.MAX)
+        );
+
+        Double todaySpending = getSumBySpends(todaySpends);
+        Double lastWeekDaySpending = getSumBySpends(lastWeekDaySpends);
+
+        Double spendingRatio;
+        if (lastWeekDaySpending != 0) {
+            spendingRatio = ((todaySpending - lastWeekDaySpending) / lastWeekDaySpending * 100.0);
+        } else {
+            spendingRatio = 0.0;
+        }
+
+        if (spendingRatio.isNaN()) {
+            spendingRatio = 0.0;
+        }
+
+        return spendingRatio;
+    }
+
+    private Double getSumBySpends(List<Spend> lists) {
+        return lists.stream()
+                .mapToDouble(Spend::getAmount)
+                .sum();
+    }
+
+    private Map<String, Double> getCategorySpends(List<Spend> lists) {
+        return lists.stream()
+                .collect(Collectors.groupingBy(spend -> spend.getCategory().getName(),
+                        Collectors.summingDouble(Spend::getAmount)));
+    }
+}

--- a/src/test/java/com/wanted/teamV/controller/StatisticsControllerTest.java
+++ b/src/test/java/com/wanted/teamV/controller/StatisticsControllerTest.java
@@ -1,0 +1,102 @@
+package com.wanted.teamV.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import com.wanted.teamV.dto.req.MemberJoinReqDto;
+import com.wanted.teamV.dto.req.MemberLoginReqDto;
+import com.wanted.teamV.dto.res.StatisticsResDto;
+import com.wanted.teamV.service.StatisticsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+@Transactional
+public class StatisticsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private StatisticsService statisticsService;
+
+    private String token;
+
+    @BeforeEach
+    public void commonSetup() throws Exception {
+        // 회원가입
+        MemberJoinReqDto joinReqDto = new MemberJoinReqDto("mockUser", "mockUser1234!");
+        MvcResult result = mockMvc.perform(post("/members")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinReqDto))
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+
+        // 로그인
+        MemberLoginReqDto loginReqDto = new MemberLoginReqDto("mockUser", "mockUser1234!");
+        result = mockMvc.perform(post("/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginReqDto))
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        response = result.getResponse().getContentAsString();
+        token = JsonPath.parse(response).read("$.accessToken");
+    }
+
+    @Test
+    @DisplayName("월별 통계 - 성공")
+    public void monthlyStatistics() throws Exception {
+        //given
+        StatisticsResDto response = StatisticsResDto.builder()
+                .totalSpend(35000.0)
+                .categorySpendPercentage(Map.of("식품", 150.0, "교통", 100.0))
+                .build();
+
+        //when
+        when(statisticsService.getMonthlyStatistics(anyLong())).thenReturn(response);
+
+        //then
+        mockMvc.perform(get("/statistics/monthly")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("요일별 통계 - 성공")
+    public void weeklyStatistics() throws Exception {
+        //given
+
+        //when & then
+        mockMvc.perform(get("/statistics/day")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/wanted/teamV/service/StatisticsServiceImplTest.java
+++ b/src/test/java/com/wanted/teamV/service/StatisticsServiceImplTest.java
@@ -1,0 +1,12 @@
+package com.wanted.teamV.service;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class StatisticsServiceImplTest {
+
+    @InjectMocks
+    private StatisticsService statisticsService;
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 지출 통계 더미 데이터 구현
- 월별, 요일별 통계 API 구현
- 컨트롤러 테스트 코드 구현

**TO-BE**
- 단위 테스트 구현

### 테스트
- [ ] 테스트 코드
- [x] API 테스트